### PR TITLE
Removes duplicate spring mapping in yaml

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -31,11 +31,6 @@ cloud:
          stack:
          auto: false
 
-spring:
-  servlet:
-     multipart:
-     max-file-size: 100MB
-
   spring:
     servlet:
       multipart:


### PR DESCRIPTION
Threw an error that spring was duplicated in yaml. This edit removes the duplication. 